### PR TITLE
Add `noreturn` attribute to crash()

### DIFF
--- a/oogabooga/cpu.c
+++ b/oogabooga/cpu.c
@@ -111,7 +111,7 @@ typedef struct Cpu_Capabilities {
 	#define alignat(x) __attribute__((aligned(x)))
     #define COMPILER_HAS_MEMCPY_INTRINSICS 1
     
-    inline void 
+    inline void __attribute__((noreturn))
     crash() {
 		__builtin_trap();
 		volatile int *a = 0;


### PR DESCRIPTION
If my understanding is correct, since `crash()` stops the program via `__builtin_trap()`, adding the `noreturn` attribute would allow the compiler to optimize in certain cases. Consider the case of an `assert()` on a pointer. Since `assert()` uses `crash()` if the pointer is `NULL`, this lets the compiler correctly discern that the pointer in any code after the assert will in fact not be null.