### PR TITLE
added function that checks if the audio player has reached the end of its source sample (e.g. has finished playing).

### DIFF
--- a/oogabooga/audio.c
+++ b/oogabooga/audio.c
@@ -22,6 +22,7 @@
 	void    audio_player_set_state(Audio_Player *p, Audio_Player_State state);
 	void    audio_player_set_time_stamp(Audio_Player *p, float64 time_in_seconds);
 	void    audio_player_set_progression_factor(Audio_Player *p, float64 factor);
+    bool    audio_player_at_source_end(Audio_Player *p);
 	float64 audio_player_get_time_stamp(Audio_Player *p);
 	float64 audio_player_get_current_progression_factor(Audio_Player *p);
 	void    audio_player_set_source(Audio_Player *p, Audio_Source src, bool retain_progression_factor);
@@ -1253,6 +1254,19 @@ audio_player_set_time_stamp(Audio_Player *p, float64 time_in_seconds) {
 	
 	spinlock_release(&p->sample_lock);
 }
+
+bool 
+audio_player_at_source_end(Audio_Player *p) {
+	spinlock_acquire_or_wait(&p->sample_lock);
+	assert(p->frame_index <= p->source.number_of_frames);
+	
+    bool finished = p->frame_index == p->source.number_of_frames;
+	
+	spinlock_release(&p->sample_lock);
+
+    return finished;
+}
+
 void // 0 - 1
 audio_player_set_progression_factor(Audio_Player *p, float64 factor) {
 	spinlock_acquire_or_wait(&p->sample_lock);


### PR DESCRIPTION
Hello I was doing some work with audio playing and found out that there's no function that tells if its at the end of Audio_Source.
It could be used in situations when you set `release_when_done` to `false` and need to restart sample after its done playing (Because it still in AUDIO_PLAYER_STATE_PLAYING so it starts playing again). 
