### PR TITLE
add build script for linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -d build ]; then
+    rm -r build
+fi
+
+CC=x86_64-w64-mingw32-gcc
+CFLAGS="-g -O0 -std=c11 --static -D_CRT_SECURE_NO_WARNINGS
+        -Wextra -Wno-sign-compare -Wno-unused-parameter
+        -lkernel32 -lgdi32 -luser32 -lruntimeobject
+        -lwinmm -ld3d11 -ldxguid -ld3dcompiler 
+        -lshlwapi -lole32 -lavrt -lksuser -ldbghelp"
+SRC=../build.c
+EXENAME=game.exe
+
+mkdir build
+cd build
+$CC $SRC -o $EXENAME $CFLAGS
+cd ..

--- a/oogabooga/audio.c
+++ b/oogabooga/audio.c
@@ -369,10 +369,10 @@ wav_read_frames(Wav_Stream *wav, Audio_Format format, void *frames,
 		= number_of_frames*max(format.channels,wav->channels)*4;
 	
 	// #Cleanup #Memory refactor intermediate buffers
-	thread_local local_persist void *raw_buffer = 0;
-	thread_local local_persist u64  raw_buffer_size = 0;
-	thread_local local_persist void *convert_buffer = 0;
-	thread_local local_persist u64  convert_buffer_size = 0;
+	local_persist thread_local void *raw_buffer = 0;
+	local_persist thread_local u64  raw_buffer_size = 0;
+	local_persist thread_local void *convert_buffer = 0;
+	local_persist thread_local u64  convert_buffer_size = 0;
 	if (!raw_buffer || required_size > raw_buffer_size) {
 		if (raw_buffer) dealloc(get_heap_allocator(), raw_buffer);
 		
@@ -747,8 +747,8 @@ audio_source_get_frames(Audio_Source *src, u64 first_frame_index,
 		u64 required_size = convert_frame_size*number_of_frames;
 		
 		// #Cleanup #Memory refactor intermediate buffers
-		thread_local local_persist void *convert_buffer = 0;
-		thread_local local_persist u64  convert_buffer_size = 0;
+		local_persist thread_local void *convert_buffer = 0;
+		local_persist thread_local u64  convert_buffer_size = 0;
 		if (!convert_buffer || required_size > convert_buffer_size) {
 			if (convert_buffer) dealloc(get_heap_allocator(), convert_buffer);
 			
@@ -1671,10 +1671,10 @@ do_program_audio_sample(u64 number_of_output_frames, Audio_Format out_format,
 	Audio_Player_Block *block = &audio_player_block;
 	
 	// #Cleanup #Memory refactor intermediate buffers
-	thread_local local_persist void *mix_buffer = 0;
-	thread_local local_persist u64 mix_buffer_size;
-	thread_local local_persist void *convert_buffer = 0;
-	thread_local local_persist u64 convert_buffer_size;
+	local_persist thread_local void *mix_buffer = 0;
+	local_persist thread_local u64 mix_buffer_size;
+	local_persist thread_local void *convert_buffer = 0;
+	local_persist thread_local u64 convert_buffer_size;
 	
 	memset(mix_buffer, 0, mix_buffer_size);
 	

--- a/oogabooga/oogabooga.c
+++ b/oogabooga/oogabooga.c
@@ -229,7 +229,7 @@ typedef u8 bool;
 #ifdef _WIN32
 	#define COBJMACROS
 	#undef noreturn
-	#include <Windows.h>
+	#include <windows.h>
     #if CONFIGURATION == DEBUG
     	#include <dbghelp.h>
     #endif

--- a/oogabooga/os_impl_windows.c
+++ b/oogabooga/os_impl_windows.c
@@ -1,6 +1,6 @@
 
 #define CINTERFACE
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <audioclient.h>
 #include <audiopolicy.h>
 #include <mmdeviceapi.h>
@@ -1308,7 +1308,7 @@ win32_mouse_pointer_kind_to_win32(Mouse_Pointer_Kind k) {
 
 void ogb_instance
 os_set_mouse_pointer_standard(Mouse_Pointer_Kind kind) {
-    thread_local local_persist HCURSOR loaded_pointers[MOUSE_POINTER_MAX] = {0};
+    local_persist thread_local HCURSOR loaded_pointers[MOUSE_POINTER_MAX] = {0};
     
     if (loaded_pointers[kind] == 0) {
         loaded_pointers[kind] = LoadCursor(0, win32_mouse_pointer_kind_to_win32(kind));


### PR DESCRIPTION
this add the ability for linux users to build windows games

the script uses mingw-gcc instead of clang, according to [GNU standard](https://gcc.gnu.org/onlinedocs/gcc/extensions-to-the-c-language-family/thread-local-storage.html) the static keyword should be before __thread (in the case of this code base thread_local and local_persist) , otherwise the compiler will error out

in windows the filenames arent case sensitive but in UNIX like system they are, I change include to mach mingw windows headers on linux

this successfully compiles all the examples and execute them successfully using wine, except for those who uses arial font, because it cant find it (using any other font fixes it)